### PR TITLE
Fix GitHub URLs

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -33,9 +33,9 @@ jobs:
         PYTHONUTF8: 1
       run: |
         python -m pip install --upgrade pip
-        pip install git+https://github.com/Spine-project/Spine-Database-API.git#egg=spinedb_api
+        pip install git+https://github.com/spine-tools/Spine-Database-API.git#egg=spinedb_api
         pip install .
-        pip install --no-deps git+https://github.com/Spine-project/spine-items.git#egg=spine_items
+        pip install --no-deps git+https://github.com/spine-tools/spine-items.git#egg=spine_items
         pip install coverage
         pip install codecov
     - name: List packages

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Spine Engine
 
 [![Python](https://img.shields.io/badge/python-3.7%20|%203.8%20|%203.9%20|%203.10-blue.svg)](https://www.python.org/downloads/release/python-379/)
-[![Unit tests](https://github.com/Spine-project/spine-engine/workflows/Unit%20tests/badge.svg)](https://github.com/Spine-project/spine-engine/actions?query=workflow%3A"Unit+tests")
-[![codecov](https://codecov.io/gh/Spine-project/spine-engine/branch/master/graph/badge.svg)](https://codecov.io/gh/Spine-project/spine-engine)
+[![Unit tests](https://github.com/spine-tools/spine-engine/workflows/Unit%20tests/badge.svg)](https://github.com/spine-tools/spine-engine/actions?query=workflow%3A"Unit+tests")
+[![codecov](https://codecov.io/gh/spine-tools/spine-engine/branch/master/graph/badge.svg)](https://codecov.io/gh/spine-tools/spine-engine)
 [![PyPI version](https://badge.fury.io/py/spine-engine.svg)](https://badge.fury.io/py/spine-engine)
 
-A Python package to coordinate the execution of [Spine Toolbox](https://github.com/Spine-project/Spine-Toolbox) workflows.
+A Python package to coordinate the execution of [Spine Toolbox](https://github.com/spine-tools/Spine-Toolbox) workflows.
 
 ## License
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     long_description_content_type="text/markdown",
     author="Spine Project consortium",
     author_email="spine_info@vtt.fi",
-    url="https://github.com/Spine-project/spine-engine",
+    url="https://github.com/spine-tools/spine-engine",
     packages=find_packages(exclude=("tests", "tests.*")),
     package_data={'spine_engine': ['execution_managers/spine_repl.jl']},
     license="LGPL-3.0-or-later",
@@ -58,7 +58,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     project_urls={
-        "Issue Tracker": "https://github.com/Spine-project/spine-engine/issues",
+        "Issue Tracker": "https://github.com/spine-tools/spine-engine/issues",
         #"Documentation": ""
     },
 )


### PR DESCRIPTION
Spine-project is now spine-tools.

Re spine-tools/Spine-Toolbox#1931

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
