### PR TITLE
Fix jump validation

### DIFF
--- a/spine_engine/spine_engine.py
+++ b/spine_engine/spine_engine.py
@@ -837,7 +837,7 @@ def validate_single_jump(jump, jumps, dag, items_by_jump=None):
         jump (Jump): the jump to check
         jumps (list of Jump): all jumps in dag
         dag (DiGraph): jumps' DAG
-        items_by_jump (dict): mapping jumps to a set of items in between destination and source
+        items_by_jump (dict, optional): mapping jumps to a set of items in between destination and source
     """
     if not jump.ready_to_execute():
         raise EngineInitFailed(f"Jump {jump.name} is not ready for execution.")
@@ -851,7 +851,7 @@ def validate_single_jump(jump, jumps, dag, items_by_jump=None):
         jump_items = items_by_jump[jump]
         other_items = items_by_jump[other]
         intersection = jump_items & other_items
-        if intersection not in ({}, jump_items, other_items):
+        if intersection not in (set(), jump_items, other_items):
             raise EngineInitFailed(f"{jump.name} cannot partially overlap {other.name}.")
     if not dag.has_node(jump.destination):
         raise EngineInitFailed(f"Loop destination '{jump.destination}' not found in DAG")

--- a/tests/test_spine_engine.py
+++ b/tests/test_spine_engine.py
@@ -10,7 +10,7 @@
 ######################################################################################################################
 
 """
-Unit tests for SpineEngine class.
+Unit tests for `spine_engine` module.
 
 Inspired from tests for spinetoolbox.ExecutionInstance and spinetoolbox.ResourceMap,
 and intended to supersede them.
@@ -29,6 +29,9 @@ from spinedb_api.filters.scenario_filter import scenario_filter_config
 from spinedb_api.filters.tool_filter import tool_filter_config
 from spinedb_api.filters.execution_filter import execution_filter_config
 from spinedb_api.filters.tools import clear_filter_configs
+from spine_engine.exception import EngineInitFailed
+from spine_engine.spine_engine import validate_single_jump
+from spine_engine.utils.helpers import make_dag
 from spine_engine import ExecutionDirection, SpineEngine, SpineEngineState, ItemExecutionFinishState
 from spine_engine.project_item.connection import Jump, Connection
 from spine_engine.project_item.project_item_resource import ProjectItemResource
@@ -818,6 +821,18 @@ class TestSpineEngine(unittest.TestCase):
                     self.assertEqual(clear_filter_configs(resource.url), expected_resource.url)
                     for key, value in expected_resource.metadata.items():
                         self.assertEqual(resource.metadata[key], value)
+
+
+class TestValidateSingleJump(unittest.TestCase):
+    def test_bug(self):
+        node_successors = {"a": ["b"], "b": ["c"], "c": "d"}
+        dag = make_dag(node_successors)
+        jumps = [Jump("b", "top", "a", "top"), Jump("d", "top", "c", "top")]
+        jump_to_check = jumps[0]
+        try:
+            validate_single_jump(jump_to_check, jumps, dag)
+        except EngineInitFailed:
+            self.fail("validate_single_jump shouldn't have raised")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
We were accidentally comparing a `set` to a `dict` in `validate_single_jump()`.

Fixes #80

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
