### PR TITLE
Make dagster pipelines based on selected items and their direct prede…

### DIFF
--- a/spine_engine/execution_managers/conda_kernel_spec_manager.py
+++ b/spine_engine/execution_managers/conda_kernel_spec_manager.py
@@ -22,8 +22,8 @@ RUNNER_COMMAND = ["python", "-m", "spine_engine.execution_managers.conda_kernel_
 
 
 class CondaKernelSpecManager(KernelSpecManager):
-    """ A custom KernelSpecManager able to search for conda environments and
-        create kernelspecs for them.
+    """A custom KernelSpecManager able to search for conda environments and
+    create kernelspecs for them.
     """
 
     conda_only = Bool(
@@ -102,8 +102,8 @@ class CondaKernelSpecManager(KernelSpecManager):
 
     @staticmethod
     def clean_kernel_name(kname):
-        """ Replaces invalid characters in the Jupyter kernelname, with
-            a bit of effort to preserve readability.
+        """Replaces invalid characters in the Jupyter kernelname, with
+        a bit of effort to preserve readability.
         """
         try:
             kname.encode('ascii')
@@ -119,10 +119,10 @@ class CondaKernelSpecManager(KernelSpecManager):
 
     @property
     def _conda_info(self):
-        """ Get and parse the whole conda information output
+        """Get and parse the whole conda information output
 
-            Caches the information for CACHE_TIMEOUT seconds, as this is
-            relatively expensive.
+        Caches the information for CACHE_TIMEOUT seconds, as this is
+        relatively expensive.
         """
 
         expiry = self._conda_info_cache_expiry
@@ -149,10 +149,10 @@ class CondaKernelSpecManager(KernelSpecManager):
         return self._conda_info_cache
 
     def _all_envs(self):
-        """ Find all of the environments we should be checking. We skip
-            environments in the conda-bld directory as well as environments
-            that match our env_filter regex. Returns a dict with canonical
-            environment names as keys, and full paths as values.
+        """Find all of the environments we should be checking. We skip
+        environments in the conda-bld directory as well as environments
+        that match our env_filter regex. Returns a dict with canonical
+        environment names as keys, and full paths as values.
         """
         conda_info = self._conda_info
         envs = conda_info['envs']
@@ -196,14 +196,14 @@ class CondaKernelSpecManager(KernelSpecManager):
         return all_envs
 
     def _all_specs(self):
-        """ Find the all kernel specs in all environments.
+        """Find the all kernel specs in all environments.
 
-            Returns a dict with unique env names as keys, and the kernel.json
-            content as values, modified so that they can be run properly in
-            their native environments.
+        Returns a dict with unique env names as keys, and the kernel.json
+        content as values, modified so that they can be run properly in
+        their native environments.
 
-            Caches the information for CACHE_TIMEOUT seconds, as this is
-            relatively expensive.
+        Caches the information for CACHE_TIMEOUT seconds, as this is
+        relatively expensive.
         """
 
         all_specs = {}
@@ -319,10 +319,10 @@ class CondaKernelSpecManager(KernelSpecManager):
         return kspecs
 
     def find_kernel_specs(self):
-        """ Returns a dict mapping kernel names to resource directories.
+        """Returns a dict mapping kernel names to resource directories.
 
-            The update process also adds the resource dir for the conda
-            environments.
+        The update process also adds the resource dir for the conda
+        environments.
         """
         if self.conda_only:
             kspecs = {}
@@ -339,10 +339,10 @@ class CondaKernelSpecManager(KernelSpecManager):
         return kspecs
 
     def get_kernel_spec(self, kernel_name):
-        """ Returns a :class:`KernelSpec` instance for the given kernel_name.
+        """Returns a :class:`KernelSpec` instance for the given kernel_name.
 
-            Additionally, conda kernelspecs are generated on the fly
-            accordingly with the detected environments.
+        Additionally, conda kernelspecs are generated on the fly
+        accordingly with the detected environments.
         """
 
         res = self._conda_kspecs.get(kernel_name)
@@ -355,9 +355,9 @@ class CondaKernelSpecManager(KernelSpecManager):
         return res
 
     def get_all_specs(self):
-        """ Returns a dict mapping kernel names to dictionaries with two
-            entries: "resource_dir" and "spec". This was added to fill out
-            the full public interface to KernelManagerSpec.
+        """Returns a dict mapping kernel names to dictionaries with two
+        entries: "resource_dir" and "spec". This was added to fill out
+        the full public interface to KernelManagerSpec.
         """
         res = {}
         for name, resource_dir in self.find_kernel_specs().items():

--- a/spine_engine/multithread_executor/multithread.py
+++ b/spine_engine/multithread_executor/multithread.py
@@ -104,7 +104,6 @@ class MultithreadExecutor(Executor):
                 loop_iteration_counters = {}
                 steps_by_key = {}
                 while not active_execution.is_complete or active_iters:
-
                     # start iterators
                     while len(active_iters) < limit:
                         candidate_steps = active_execution.get_steps_to_execute(limit=(limit - len(active_iters)))

--- a/spine_engine/server/certificate_creator.py
+++ b/spine_engine/server/certificate_creator.py
@@ -56,7 +56,6 @@ class CertificateCreator:
 
 
 def main(args):
-
     if len(args) < 2:
         script_dir = os.path.dirname(os.path.abspath(__file__))
         base_dir = os.path.join(script_dir, "certs")

--- a/spine_engine/server/request.py
+++ b/spine_engine/server/request.py
@@ -45,9 +45,9 @@ class Request:
 
     def msg(self):
         """Returns a list containing three binary frames.
-         First frame is the connection id (added by the frontend ROUTER socket at receiver).
-         The second frame is empty (added by the frontend ROUTER socket at receiver).
-         The third frame contains the data sent by client."""
+        First frame is the connection id (added by the frontend ROUTER socket at receiver).
+        The second frame is empty (added by the frontend ROUTER socket at receiver).
+        The third frame contains the data sent by client."""
         return self._msg
 
     def cmd(self):

--- a/spine_engine/server/util/zip_handler.py
+++ b/spine_engine/server/util/zip_handler.py
@@ -70,7 +70,7 @@ class ZipHandler:
     @staticmethod
     def delete_folder(folder):
         """Removes the provided directory and all it's contents.
-        
+
         Args:
             folder: Directory to be removed
         """

--- a/spine_engine/utils/helpers.py
+++ b/spine_engine/utils/helpers.py
@@ -250,22 +250,28 @@ def get_julia_env(settings):
     return julia, project
 
 
-def make_dag(node_successors):
-    """Builds a DAG from node successors.
+def make_dag(edges, permitted_nodes=None):
+    """Builds a DAG from edges or if no edges exist, from permitted_nodes.
 
     Args:
-        node_successors (dict): mapping from item name to list of its successors' names
+        edges (dict): Mapping from item name to list of its successors' names
+        permitted_nodes (dict): Mapping from item name to boolean value indicating if item is selected
 
     Returns:
-        DiGraph: directed acyclic graph
+        DiGraph: Directed acyclic graph
     """
     graph = networkx.DiGraph()
-    graph.add_nodes_from(node_successors)
-    for node, successors in node_successors.items():
-        if successors is None:
-            continue
-        for successor in successors:
-            graph.add_edge(node, successor)
+    if not edges:
+        # Make a single node DAG with no edges
+        nodes = [node_name for node_name, permitted in permitted_nodes.items() if permitted]
+        graph.add_nodes_from(nodes)
+    else:
+        graph.add_nodes_from(edges)
+        for node, successors in edges.items():
+            if successors is None:
+                continue
+            for successor in successors:
+                graph.add_edge(node, successor)
     return graph
 
 

--- a/tests/test_spine_engine.py
+++ b/tests/test_spine_engine.py
@@ -825,8 +825,8 @@ class TestSpineEngine(unittest.TestCase):
 
 class TestValidateSingleJump(unittest.TestCase):
     def test_bug(self):
-        node_successors = {"a": ["b"], "b": ["c"], "c": "d"}
-        dag = make_dag(node_successors)
+        edges = {"a": ["b"], "b": ["c"], "c": "d"}
+        dag = make_dag(edges)
         jumps = [Jump("b", "top", "a", "top"), Jump("d", "top", "c", "top")]
         jump_to_check = jumps[0]
         try:

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -21,27 +21,35 @@ from spine_engine.utils.helpers import make_dag, gather_leaf_data, get_file_size
 
 
 class TestMakeDAG(unittest.TestCase):
-    def test_empty_dag(self):
-        node_successors = {}
-        dag = make_dag(node_successors)
-        self.assertFalse(dag)
-
     def test_single_node(self):
-        node_successors = {"a": None}
-        dag = make_dag(node_successors)
+        edges = {"a": None}
+        dag = make_dag(edges)
         self.assertEqual(len(dag), 1)
 
     def test_two_nodes(self):
-        node_successors = {"a": ["b"], "b": None}
-        dag = make_dag(node_successors)
+        edges = {"a": ["b"], "b": None}
+        dag = make_dag(edges)
         self.assertEqual(set(dag.nodes), {"a", "b"})
         self.assertEqual(list(dag.edges), [("a", "b")])
 
     def test_branch(self):
-        node_successors = {"a": ["b", "c"], "b": None, "c": None}
-        dag = make_dag(node_successors)
+        edges = {"a": ["b", "c"], "b": None, "c": None}
+        dag = make_dag(edges)
         self.assertEqual(set(dag.nodes), {"a", "b", "c"})
         self.assertEqual(set(dag.edges), {("a", "b"), ("a", "c")})
+
+    def test_no_edges_one_node(self):
+        edges = {}
+        permitted_nodes = {"a": True}
+        dag = make_dag(edges, permitted_nodes)
+        self.assertEqual(len(dag), 1)
+
+    def test_no_edges_two_nodes(self):
+        # Note: This does not happen in practice because unconnected nodes will be executed on different Engines
+        edges = {}
+        permitted_nodes = {"a": True, "b": True}
+        dag = make_dag(edges, permitted_nodes)
+        self.assertEqual(len(dag), 2)
 
 
 class TestRemoveCredentialsFromUrl(unittest.TestCase):


### PR DESCRIPTION
…cessors and successors only

Dagster pipelines included every single item in the DAG even in cases when only a subset was selected for execution. This resulted in execution being slower than it needed to be and some confusion on why it looked like it was executing also items that were not even selected. This commit fixes the problem by not filling up the Dagster pipelines with items that should not be touched.

Also, refactored SpineEngine class to hopefully make it more readable and ran black.

Re spine-tools/Spine-Toolbox#1990

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
