### PR TITLE
Don't access file system in path_in_dir()

### DIFF
--- a/spine_engine/utils/serialization.py
+++ b/spine_engine/utils/serialization.py
@@ -19,16 +19,21 @@ Functions to (de)serialize stuff.
 import os
 import sys
 import urllib
+from pathlib import Path
 from urllib.parse import urljoin
 
 
 def path_in_dir(path, directory):
-    """Returns True if the given path is in the given directory."""
-    try:
-        retval = os.path.samefile(os.path.commonpath((path, directory)), directory)
-    except ValueError:
-        return False
-    return retval
+    """Returns True if the given path is in the given directory.
+
+    Args:
+        path (str): path to test
+        directory (str): directory to test against
+
+    Returns:
+        bool: True if path is in directory, False otherwise
+    """
+    return Path(os.path.commonpath((path, directory))) == Path(directory)
 
 
 def serialize_path(path, project_dir):


### PR DESCRIPTION
This replaces the call to `os.path.samefile()` by a comparison of `Path` objects in `path_in_dir()` to avoid requiring the directory to be physically present. This will make writing unit tests a bit easier.

Re spine-tools/Spine-Toolbox#1668

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
