### PR TITLE
Ensure multiprocessing manager is always shut down

### DIFF
--- a/tests/test_spine_engine.py
+++ b/tests/test_spine_engine.py
@@ -705,25 +705,21 @@ class TestSpineEngine(unittest.TestCase):
         connections = []
         jumps = [Jump("item", "bottom", "item", "top", self._LOOP_TWICE).to_dict()]
         execution_permits = {"item": True}
-        with patch("spine_engine.spine_engine.mp.Manager") as mock_multiprocessing_manager:
-            mock_lock = object()
+        mock_lock = object()
 
-            class MockLockConstructor:
-                def Lock(self):
-                    return mock_lock
-
-            mock_multiprocessing_manager.return_value = MockLockConstructor()
-            engine = SpineEngine(
-                items=items,
-                connections=connections,
-                jumps=jumps,
-                execution_permits=execution_permits,
-                items_module_name="items_module",
-            )
-            engine.make_item = lambda name, direction: engine._items[name]
-            engine.run()
-            self.assertEqual(mock_item.execute.call_args_list, 2 * [call([], [], mock_lock)])
-            self.assertEqual(engine.state(), SpineEngineState.COMPLETED)
+        engine = SpineEngine(
+            items=items,
+            connections=connections,
+            jumps=jumps,
+            execution_permits=execution_permits,
+            items_module_name="items_module",
+        )
+        engine.make_item = lambda name, direction: engine._items[name]
+        engine.run()
+        lock_1 = mock_item.execute.call_args_list[0].args[-1]
+        lock_2 = mock_item.execute.call_args_list[1].args[-1]
+        self.assertEqual(mock_item.execute.call_args_list, [call([], [], lock_1), call([], [], lock_2)])
+        self.assertEqual(engine.state(), SpineEngineState.COMPLETED)
 
     @unittest.skip("Hangs because something's not right in SpineDBServer")
     def test_jump_resources_get_passed_correctly(self):


### PR DESCRIPTION
The manager is now in a `with` block so no processes are left laying behind.

Fixes spine-tools/Spine-Toolbox#2056

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black
- [ ] Unit tests pass
