### PR TITLE
Fix scenario execution using Jupyter Consoles

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -39,6 +39,10 @@ jobs:
     - name: List packages
       run:
         pip list
+    - name: Install python3 kernelspecs
+      run: |
+        pip install ipykernel
+        python -m ipykernel install --user
     - name: Run tests
       run: |
         if [ "$RUNNER_OS" != "Windows" ]; then

--- a/spine_engine/execution_managers/kernel_execution_manager.py
+++ b/spine_engine/execution_managers/kernel_execution_manager.py
@@ -29,6 +29,7 @@ from spine_engine.execution_managers.conda_kernel_spec_manager import CondaKerne
 
 class GroupedKernelManager(KernelManager):
     """Kernel Manager that supports group ID's."""
+
     def __init__(self, *args, **kwargs):
         group_id = kwargs.pop("group_id", "")
         super().__init__(*args, **kwargs)

--- a/spine_engine/execution_managers/kernel_execution_manager.py
+++ b/spine_engine/execution_managers/kernel_execution_manager.py
@@ -171,7 +171,6 @@ class KernelExecutionManager(ExecutionManagerBase):
         super().__init__(logger)
         self._msg_head = dict(kernel_name=kernel_name)
         self._commands = commands
-        print(commands)
         self._cmd_failed = False
         kwargs["stdout"] = open(os.devnull, 'w')
         kwargs["stderr"] = open(os.devnull, 'w')

--- a/spine_engine/execution_managers/kernel_execution_manager.py
+++ b/spine_engine/execution_managers/kernel_execution_manager.py
@@ -55,17 +55,20 @@ class _KernelManagerFactory(metaclass=Singleton):
     _key_by_connection_file = {}
     """Maps connection file path to filter_id (str)"""
 
-    def _make_kernel_manager(self, kernel_name, group_id, server_ip):
+    def _make_kernel_manager(self, kernel_name, group_id, server_ip, filter_id):
         """Creates a new kernel manager if necessary or returns an existing one.
 
         Args:
-            kernel_name (str): the kernel
-            group_id (str): item group that will execute using this kernel
+            kernel_name (str): The kernel
+            group_id (str): Item group that will execute using this kernel
             server_ip (str): Engine Server IP address. '127.0.0.1' when execution happens locally
+            filter_id (str): Filter Id
 
         Returns:
-            KernelManager
+            GroupedKernelManager
         """
+        if not filter_id == "":
+            group_id = filter_id  # Ignore group ID in case filter ID exists
         for k in self._kernel_managers:
             # Reuse kernel manager if using same group id and kernel and it's idle
             km = self._kernel_managers[k]
@@ -95,7 +98,8 @@ class _KernelManagerFactory(metaclass=Singleton):
             KernelManager
         """
         server_ip = kwargs.pop("server_ip", "")
-        km = self._make_kernel_manager(kernel_name, group_id, server_ip)
+        filter_id = logger.msg_kernel_execution.filter_id
+        km = self._make_kernel_manager(kernel_name, group_id, server_ip, filter_id)
         conda_exe = kwargs.pop("conda_exe", "")
         if environment == "conda":
             try:

--- a/tests/execution_managers/test_kernel_execution_manager.py
+++ b/tests/execution_managers/test_kernel_execution_manager.py
@@ -31,6 +31,7 @@ class TestKernelExecutionManager(unittest.TestCase):
 
     def test_kernel_execution_manager(self):
         logger = MagicMock()
+        logger.msg_kernel_execution.filter_id = ""
         with tempfile.NamedTemporaryFile("w+", encoding="utf-8") as script_file:
             script_file.write('print("hello")')
             script_file.seek(0)
@@ -54,7 +55,9 @@ class TestKernelExecutionManager(unittest.TestCase):
 
     def test_kernel_manager_sharing(self):
         logger1 = MagicMock()
+        logger1.msg_kernel_execution.filter_id = ""
         logger2 = MagicMock()
+        logger2.msg_kernel_execution.filter_id = ""
         with tempfile.NamedTemporaryFile("w+", encoding="utf-8") as script_file1, tempfile.NamedTemporaryFile("w+", encoding="utf-8") as script_file2:
             script_file1.write('print("hello")')
             script_file1.seek(0)
@@ -93,7 +96,9 @@ class TestKernelExecutionManager(unittest.TestCase):
 
     def test_two_kernel_managers(self):
         logger1 = MagicMock()
+        logger1.msg_kernel_execution.filter_id = ""
         logger2 = MagicMock()
+        logger2.msg_kernel_execution.filter_id = ""
         with tempfile.NamedTemporaryFile("w+", encoding="utf-8") as script_file1, tempfile.NamedTemporaryFile("w+", encoding="utf-8") as script_file2:
             script_file1.write('print("hello")')
             script_file1.seek(0)

--- a/tests/execution_managers/test_kernel_execution_manager.py
+++ b/tests/execution_managers/test_kernel_execution_manager.py
@@ -18,7 +18,6 @@ from jupyter_client.kernelspec import NATIVE_KERNEL_NAME  # =='python3'
 
 
 class TestKernelExecutionManager(unittest.TestCase):
-
     @staticmethod
     def release_exec_mngr_resources(mngr):
         """Frees resources after exec_mngr has been used. Consider putting
@@ -58,7 +57,9 @@ class TestKernelExecutionManager(unittest.TestCase):
         logger1.msg_kernel_execution.filter_id = ""
         logger2 = MagicMock()
         logger2.msg_kernel_execution.filter_id = ""
-        with tempfile.NamedTemporaryFile("w+", encoding="utf-8") as script_file1, tempfile.NamedTemporaryFile("w+", encoding="utf-8") as script_file2:
+        with tempfile.NamedTemporaryFile("w+", encoding="utf-8") as script_file1, tempfile.NamedTemporaryFile(
+            "w+", encoding="utf-8"
+        ) as script_file2:
             script_file1.write('print("hello")')
             script_file1.seek(0)
             script_file2.write('print("hello again")')
@@ -99,7 +100,9 @@ class TestKernelExecutionManager(unittest.TestCase):
         logger1.msg_kernel_execution.filter_id = ""
         logger2 = MagicMock()
         logger2.msg_kernel_execution.filter_id = ""
-        with tempfile.NamedTemporaryFile("w+", encoding="utf-8") as script_file1, tempfile.NamedTemporaryFile("w+", encoding="utf-8") as script_file2:
+        with tempfile.NamedTemporaryFile("w+", encoding="utf-8") as script_file1, tempfile.NamedTemporaryFile(
+            "w+", encoding="utf-8"
+        ) as script_file2:
             script_file1.write('print("hello")')
             script_file1.seek(0)
             script_file2.write('print("hello again")')

--- a/tests/execution_managers/test_kernel_execution_manager.py
+++ b/tests/execution_managers/test_kernel_execution_manager.py
@@ -1,0 +1,145 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# This file is part of Spine Engine.
+# Spine Engine is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+"""Unit tests for ``kernel_execution_manager`` module."""
+import os
+import unittest
+import tempfile
+from unittest.mock import MagicMock
+from spine_engine.execution_managers.kernel_execution_manager import KernelExecutionManager, _kernel_manager_factory
+from jupyter_client.kernelspec import NATIVE_KERNEL_NAME  # =='python3'
+
+
+class TestKernelExecutionManager(unittest.TestCase):
+
+    @staticmethod
+    def release_exec_mngr_resources(mngr):
+        """Frees resources after exec_mngr has been used. Consider putting
+        this to KernelExecutionManager.close() or something."""
+        if not mngr._kernel_client.context.closed:
+            mngr._kernel_client.context.term()  # ResourceWarning: Unclosed <zmq.Context() happens without this
+        mngr.std_out.close()  # Prevents ResourceWarning: unclosed file <_io.TextIOWrapper name='nul' ...
+        mngr.std_err.close()  # Prevents ResourceWarning: unclosed file <_io.TextIOWrapper name='nul' ...
+        return mngr
+
+    def test_kernel_execution_manager(self):
+        logger = MagicMock()
+        with tempfile.NamedTemporaryFile("w+", encoding="utf-8") as script_file:
+            script_file.write('print("hello")')
+            script_file.seek(0)
+            d, fname = os.path.split(script_file.name)
+            cmds = [f"%cd -q {d}", f"%run {fname}"]
+            exec_mngr = KernelExecutionManager(logger, NATIVE_KERNEL_NAME, *cmds, group_id="SomeGroup")
+            self.assertTrue(exec_mngr._kernel_manager.is_alive())
+            exec_mngr = self.replace_client(exec_mngr)
+            retval = exec_mngr.run_until_complete()  # Run commands
+            self.assertEqual(0, retval)
+            self.assertTrue(exec_mngr._kernel_manager.is_alive())
+            exec_mngr = self.release_exec_mngr_resources(exec_mngr)
+            exec_mngr = None
+            self.assertEqual(1, _kernel_manager_factory.n_kernel_managers())
+            _kernel_manager_factory.kill_kernel_managers()
+            self.assertEqual(0, _kernel_manager_factory.n_kernel_managers())
+            message_emits = logger.msg_kernel_execution.emit.call_args_list
+            expected_msg = {"type": "execution_started", "kernel_name": NATIVE_KERNEL_NAME}
+            self.assertEqual(2, len(message_emits))
+            self.assertEqual(expected_msg, message_emits[1][0][0])
+
+    def test_kernel_manager_sharing(self):
+        logger1 = MagicMock()
+        logger2 = MagicMock()
+        with tempfile.NamedTemporaryFile("w+", encoding="utf-8") as script_file1, tempfile.NamedTemporaryFile("w+", encoding="utf-8") as script_file2:
+            script_file1.write('print("hello")')
+            script_file1.seek(0)
+            script_file2.write('print("hello again")')
+            script_file2.seek(0)
+            d1, fname1 = os.path.split(script_file1.name)
+            d2, fname2 = os.path.split(script_file2.name)
+            exec_mngr1_cmds = [f"%cd -q {d1}", f"%run {fname1}"]
+            exec_mngr2_cmds = [f"%cd -q {d2}", f"%run {fname2}"]
+            kernel_name = NATIVE_KERNEL_NAME
+            exec_mngr1 = KernelExecutionManager(logger1, kernel_name, *exec_mngr1_cmds, group_id="SomeGroup")
+            exec_mngr1 = self.replace_client(exec_mngr1)
+            retval1 = exec_mngr1.run_until_complete()  # Run commands
+            self.assertEqual(0, retval1)
+            exec_mngr2 = KernelExecutionManager(logger2, kernel_name, *exec_mngr2_cmds, group_id="SomeGroup")
+            exec_mngr2 = self.replace_client(exec_mngr2)
+            self.assertEqual(1, _kernel_manager_factory.n_kernel_managers())
+            self.assertEqual(exec_mngr1._kernel_manager, exec_mngr2._kernel_manager)
+            retval2 = exec_mngr2.run_until_complete()  # Run commands
+            self.assertEqual(0, retval2)
+            # Close
+            exec_mngr1 = self.release_exec_mngr_resources(exec_mngr1)
+            exec_mngr2 = self.release_exec_mngr_resources(exec_mngr2)
+            exec_mngr1 = None
+            exec_mngr2 = None
+            _kernel_manager_factory.kill_kernel_managers()
+            self.assertEqual(0, _kernel_manager_factory.n_kernel_managers())
+            # Check emitted messages
+            logger1_message_emits = logger1.msg_kernel_execution.emit.call_args_list
+            expected_msg = {"type": "execution_started", "kernel_name": NATIVE_KERNEL_NAME}
+            self.assertEqual(2, len(logger1_message_emits))
+            self.assertEqual(expected_msg, logger1_message_emits[1][0][0])
+            logger2_message_emits = logger2.msg_kernel_execution.emit.call_args_list
+            self.assertEqual(2, len(logger2_message_emits))
+            self.assertEqual(expected_msg, logger2_message_emits[1][0][0])
+
+    def test_two_kernel_managers(self):
+        logger1 = MagicMock()
+        logger2 = MagicMock()
+        with tempfile.NamedTemporaryFile("w+", encoding="utf-8") as script_file1, tempfile.NamedTemporaryFile("w+", encoding="utf-8") as script_file2:
+            script_file1.write('print("hello")')
+            script_file1.seek(0)
+            script_file2.write('print("hello again")')
+            script_file2.seek(0)
+            d1, fname1 = os.path.split(script_file1.name)
+            d2, fname2 = os.path.split(script_file2.name)
+            exec_mngr1_cmds = [f"%cd -q {d1}", f"%run {fname1}"]
+            exec_mngr2_cmds = [f"%cd -q {d2}", f"%run {fname2}"]
+            kernel_name = NATIVE_KERNEL_NAME
+            exec_mngr1 = KernelExecutionManager(logger1, kernel_name, *exec_mngr1_cmds, group_id="SomeGroup")
+            exec_mngr1 = self.replace_client(exec_mngr1)
+            retval1 = exec_mngr1.run_until_complete()  # Run commands
+            self.assertEqual(0, retval1)
+            exec_mngr2 = KernelExecutionManager(logger2, kernel_name, *exec_mngr2_cmds, group_id="AnotherGroup")
+            exec_mngr2 = self.replace_client(exec_mngr2)
+            self.assertEqual(2, _kernel_manager_factory.n_kernel_managers())
+            self.assertNotEqual(exec_mngr1._kernel_manager, exec_mngr2._kernel_manager)
+            retval2 = exec_mngr2.run_until_complete()  # Run commands
+            self.assertEqual(0, retval2)
+            # Close
+            exec_mngr1 = self.release_exec_mngr_resources(exec_mngr1)
+            exec_mngr2 = self.release_exec_mngr_resources(exec_mngr2)
+            exec_mngr1 = None
+            exec_mngr2 = None
+            _kernel_manager_factory.kill_kernel_managers()
+            self.assertEqual(0, _kernel_manager_factory.n_kernel_managers())
+            # Check emitted messages
+            logger1_message_emits = logger1.msg_kernel_execution.emit.call_args_list
+            expected_msg = {"type": "execution_started", "kernel_name": NATIVE_KERNEL_NAME}
+            self.assertEqual(2, len(logger1_message_emits))
+            self.assertEqual(expected_msg, logger1_message_emits[1][0][0])
+            logger2_message_emits = logger2.msg_kernel_execution.emit.call_args_list
+            self.assertEqual(2, len(logger2_message_emits))
+            self.assertEqual(expected_msg, logger2_message_emits[1][0][0])
+
+    @staticmethod
+    def replace_client(exec_mngr):
+        """Reloads the connection file, and replaces the kernel client with a new one, just like
+        we do on Toolbox side. Don't really understand why we need to do this, but I think
+        it's because of the 'classic' race condition in jupyter-client < 7.0.
+        This maybe fixed in a more recent version of jupyter-client."""
+        # exec_mngr._kernel_client.stop_channels()
+        # exec_mngr._kernel_client.context.term()  # ResourceWarning: Unclosed <zmq.Context() happens without this
+        exec_mngr._kernel_manager.load_connection_file()
+        kc = exec_mngr._kernel_manager.client()  # Make new client
+        # kc.start_channels()
+        exec_mngr._kernel_client = kc  # Replace the original client
+        return exec_mngr


### PR DESCRIPTION
We used (kernel_name, group_id) tuple for storing consoles. When executing scenarios, this tuple was always the same, which meant that only a single Jupyter console was ever launched and all scenario executions tried to use the same kernel manager.

Re spine-tools/Spine-Toolbox#2080

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
