### PR TITLE
Fix excluded item filter ids

### DIFF
--- a/spine_engine/project_item/connection.py
+++ b/spine_engine/project_item/connection.py
@@ -185,6 +185,18 @@ class FilterSettings:
                     return True
         return False
 
+    def has_any_filter_online(self):
+        """Tests in any filter is online.
+
+        Returns:
+            bool: True if any filter is online, False otherwise
+        """
+        for filters_by_type in self.known_filters.values():
+            for filters in filters_by_type.values():
+                if any(filters.values()):
+                    return True
+        return False
+
     def has_filter_online(self, filter_type):
         """Tests if any filter of given type is online.
 
@@ -192,10 +204,10 @@ class FilterSettings:
             filter_type (str): filter type to test
 
         Returns:
-            bool: True if any scenario filter is online, False otherwise
+            bool: True if any filter of filter_type is online, False otherwise
         """
         for filters_by_type in self.known_filters.values():
-            if any(online for online in filters_by_type.get(filter_type, {}).values()):
+            if any(filters_by_type.get(filter_type, {}).values()):
                 return True
         return False
 
@@ -277,6 +289,14 @@ class ResourceConvertingConnection(ConnectionBase):
     def is_filter_online_by_default(self):
         """True if new filters should be online by default."""
         return self._filter_settings.auto_online
+
+    def has_filters_online(self):
+        """Tests if connection has any online filters.
+
+        Returns:
+            bool: True if there are online filters, False otherwise
+        """
+        return self._filter_settings.has_any_filter_online()
 
     def require_filter_online(self, filter_type):
         """Tests if online filters of given type are required for execution.

--- a/spine_engine/project_item/executable_item_base.py
+++ b/spine_engine/project_item/executable_item_base.py
@@ -148,6 +148,15 @@ class ExecutableItemBase:
         """Returns the item's type identifier string."""
         raise NotImplementedError()
 
+    @staticmethod
+    def is_filter_terminus():
+        """Tests if the item 'terminates' a forked execution.
+
+        Returns:
+            bool: True if forked executions should be joined before the item, False otherwise
+        """
+        return False
+
     def output_resources(self, direction):
         """Returns output resources in the given direction.
 

--- a/spine_engine/spine_engine.py
+++ b/spine_engine/spine_engine.py
@@ -544,10 +544,10 @@ class SpineEngine:
         Args:
             context
             item_name (str)
-            forward_resource_stacks (list(tuple(ProjectItemResource))): resources comming from predecessor items -
+            forward_resource_stacks (list(tuple(ProjectItemResource))): resources coming from predecessor items -
                 one tuple of ProjectItemResource per item, where each element in the tuple corresponds to a filtered
                 execution of the item.
-            backward_resources (list(ProjectItemResource)): resources comming from successor items - just one
+            backward_resources (list(ProjectItemResource)): resources coming from successor items - just one
                 resource per item.
 
         Returns:
@@ -628,10 +628,10 @@ class SpineEngine:
 
         Args:
             item_name (str)
-            forward_resource_stacks (list(tuple(ProjectItemResource))): resources comming from predecessor items -
+            forward_resource_stacks (list(tuple(ProjectItemResource))): resources coming from predecessor items -
                 one tuple of ProjectItemResource per item, where each element in the tuple corresponds to a filtered
                 execution of the item.
-            backward_resources (list(ProjectItemResource)): resources comming from successor items - just one
+            backward_resources (list(ProjectItemResource)): resources coming from successor items - just one
                 resource per item.
             timestamp (str): timestamp for the execution filter
 

--- a/spine_engine/spine_engine.py
+++ b/spine_engine/spine_engine.py
@@ -13,7 +13,6 @@
 Contains the SpineEngine class for running Spine Toolbox DAGs.
 
 """
-
 from enum import Enum, unique
 import os
 import threading
@@ -46,6 +45,7 @@ from .execution_managers.persistent_execution_manager import (
 )
 from .utils.helpers import (
     AppSettings,
+    required_items_for_execution,
     inverted,
     create_timestamp,
     make_dag,
@@ -102,7 +102,7 @@ class SpineEngine:
     ):
         """
         Args:
-            items (list(dict)): List of executable item dicts.
+            items (dict): A mapping from item name to item dict
             specifications (dict(str,list(dict))): A mapping from item type to list of specification dicts.
             connections (list of dict): List of connection dicts
             jumps (list of dict, optional): List of jump dicts
@@ -125,7 +125,12 @@ class SpineEngine:
             execution_permits = {}
         self._execution_permits = execution_permits
         connections = list(map(Connection.from_dict, connections))  # Deserialize connections
-        self._connections = make_connections(connections, self._execution_permits)
+        project_item_loader = ProjectItemLoader()
+        self._executable_item_classes = project_item_loader.load_executable_item_classes(items_module_name)
+        required_items = required_items_for_execution(
+            self._items, connections, self._executable_item_classes, self._execution_permits
+        )
+        self._connections = make_connections(connections, required_items)
         self._connections_by_source = dict()
         self._connections_by_destination = dict()
         self._validate_and_sort_connections()
@@ -135,8 +140,6 @@ class SpineEngine:
         _set_resource_limits(self._settings, SpineEngine._resource_limit_lock)
         enable_persistent_process_creation()
         self._project_dir = project_dir
-        project_item_loader = ProjectItemLoader()
-        self._executable_item_classes = project_item_loader.load_executable_item_classes(items_module_name)
         if specifications is None:
             specifications = {}
         self._item_specifications = self._make_item_specifications(
@@ -442,11 +445,7 @@ class SpineEngine:
         )
 
     def _complete_jumps(self):
-        """Returns a dictionary mapping Jump objects to a set of solid names corresponding to items within the loop.
-
-        Returns:
-            dict
-        """
+        """Updates jumps with item and corresponding solid information."""
         for jump in self._jumps:
             src, dst = jump.source, jump.destination
             jump.item_names = {dst, src}
@@ -461,6 +460,9 @@ class SpineEngine:
 
         Args:
             item_name (str): The project item that gets executed by the solid.
+
+        Returns:
+            SolidDefinition: solid's definition
         """
 
         def compute_fn(context, inputs):

--- a/tests/project_item/test_connection.py
+++ b/tests/project_item/test_connection.py
@@ -264,6 +264,18 @@ class TestFilterSettings(unittest.TestCase):
         self.assertFalse(settings.has_filter_online(SCENARIO_FILTER_TYPE))
         self.assertFalse(settings.has_filter_online(TOOL_FILTER_TYPE))
 
+    def test_has_any_filter_online_returns_true_when_filters_are_online(self):
+        settings = FilterSettings(
+            {"database@Data Store": {SCENARIO_FILTER_TYPE: {"scenario_1": False}, TOOL_FILTER_TYPE: {"tool_1": True}}}
+        )
+        self.assertTrue(settings.has_any_filter_online())
+
+    def test_has_any_filter_online_returns_false_when_all_filters_are_offline(self):
+        settings = FilterSettings(
+            {"database@Data Store": {SCENARIO_FILTER_TYPE: {"scenario_1": False}, TOOL_FILTER_TYPE: {"tool_1": False}}}
+        )
+        self.assertFalse(settings.has_any_filter_online())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
We need to instantiate all project items along DAG paths that are downstream of a filtered connection (up to a *filter terminus*, i.e. Data Store). This ensures that all relevant items get assigned a filter id.

Fixes #99

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
