### PR TITLE
fix calling old commands in consoles

### DIFF
--- a/spine_engine/execution_managers/persistent_execution_manager.py
+++ b/spine_engine/execution_managers/persistent_execution_manager.py
@@ -696,8 +696,6 @@ class _PersistentManagerFactory(metaclass=Singleton):
         pm = self.persistent_managers.get(key)
         if pm is None:
             return
-        if sys.platform == "win32":
-            return ""
         return pm.get_history_item(text, prefix, backwards)
 
     def kill_manager_processes(self):

--- a/spine_engine/execution_managers/spine_repl.jl
+++ b/spine_engine/execution_managers/spine_repl.jl
@@ -19,7 +19,7 @@ using REPL.LineEdit
 
 _exception = false
 # History related stuff. This works with julia 1.0 to 1.6 at least
-term = TerminalBuffer(IOBuffer())
+term = TTYTerminal("", stdin, IOBuffer(), stderr)
 repl = LineEditREPL(term, false)
 repl.history_file = true
 interface = REPL.setup_interface(repl)


### PR DESCRIPTION
Fixed calling history items by pressing up- and down-arrows on the keyboard in Julia console.

Fixes spine-tools/Spine-Toolbox#1805

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [ ] Unit tests pass
