### PR TITLE
Further speedup Tool's notification check

### DIFF
--- a/spine_engine/project_item/project_item_resource.py
+++ b/spine_engine/project_item/project_item_resource.py
@@ -59,6 +59,7 @@ class ProjectItemResource:
         self.type_ = type_
         self.label = label
         self._url = url
+        self._filepath = None
         self._parsed_url = urlparse(self._url)
         self.metadata = metadata if metadata is not None else dict()
         self._filterable = filterable
@@ -157,11 +158,14 @@ class ProjectItemResource:
     def url(self, url):
         self._url = url
         self._parsed_url = urlparse(self._url)
+        self._filepath = url2pathname(self._parsed_url.path)
 
     @property
     def path(self):
         """Returns the resource path in the local syntax, as obtained from parsing the url."""
-        return url2pathname(self._parsed_url.path)
+        if not self._filepath:
+            self._filepath = url2pathname(self._parsed_url.path)
+        return self._filepath
 
     @property
     def scheme(self):


### PR DESCRIPTION
If a ProjectItemResource has a filepath, instead of it being formed every time it is needed, it is now calculated only once. The check for fulfilling required files is now completed once one match is found for every required file.

Re spine-tools/Spine-Toolbox#2083

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
