### PR TITLE
Don't add --project to Julia command if there's no project

### DIFF
--- a/spine_engine/utils/helpers.py
+++ b/spine_engine/utils/helpers.py
@@ -207,13 +207,16 @@ def get_julia_command(settings):
         settings (QSettings, AppSettings)
 
     Returns:
-        list: e.g. ["path/to/julia", "--project=path/to/project/"]
+        list of str: e.g. ["path/to/julia", "--project=path/to/project/"]
     """
     env = get_julia_env(settings)
     if env is None:
         return None
     julia, project = env
-    return [julia, f"--project={project}"]
+    command = [julia]
+    if project:
+        command.append(f"--project={project}")
+    return command
 
 
 def get_julia_env(settings):


### PR DESCRIPTION
This PR fixes an issue encountered when creating Julia sysimages.

Re spine-tools/Spine-Toolbox#1225

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
