### PR TITLE
Fix links loop python script erased

### DIFF
--- a/spine_engine/project_item/connection.py
+++ b/spine_engine/project_item/connection.py
@@ -532,7 +532,7 @@ class Jump(ConnectionBase):
     """Represents a conditional jump between two project items."""
 
     def __init__(
-        self, source_name, source_position, destination_name, destination_position, condition=None, cmd_line_args=()
+        self, source_name, source_position, destination_name, destination_position, condition={}, cmd_line_args=()
     ):
         """
         Args:
@@ -543,7 +543,8 @@ class Jump(ConnectionBase):
             condition (dict): jump condition
         """
         super().__init__(source_name, source_position, destination_name, destination_position)
-        self.condition = condition if condition is not None else {"type": "python-script", "script": "exit(1)"}
+        default_condition = {"type": "python-script", "script": "exit(1)", "specification": ""}
+        self.condition = condition if condition else default_condition
         self._resources_from_source = set()
         self._resources_from_destination = set()
         self.cmd_line_args = list(cmd_line_args)


### PR DESCRIPTION
Now when the condition type of Loop is changed from Python script to Tool spec, the script is saved. The Python script editor is also disabled, and it turns grey to indicate that.

Fixes spine-tools/Spine-Toolbox#2174

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
