### PR TITLE
Ask each prompt only once

### DIFF
--- a/spine_engine/utils/queue_logger.py
+++ b/spine_engine/utils/queue_logger.py
@@ -14,6 +14,7 @@
 The QueueLogger class.
 
 """
+import time
 
 
 class _MessageBase:
@@ -77,11 +78,14 @@ class _Prompt(_MessageBase):
         self._answered_prompts = answered_prompts
 
     def emit(self, prompt):
-        prompt = {"item_name": self._item_name, **prompt}
         key = str(prompt)
         if key not in self._answered_prompts:
+            self._answered_prompts[key] = None
+            prompt = {"item_name": self._item_name, **prompt}
             self._queue.put(("prompt", prompt))
             self._answered_prompts[key] = self._prompt_queue.get()
+        while self._answered_prompts[key] is None:
+            time.sleep(0.02)
         return self._answered_prompts[key]
 
 


### PR DESCRIPTION
Also, don't generate resources if no items will consume them.

Fixes #126
## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
