### PR TITLE
Refactor Python interpreter/Julia executable discovery

### DIFF
--- a/spine_engine/project_item/connection.py
+++ b/spine_engine/project_item/connection.py
@@ -28,7 +28,7 @@ from spine_engine.project_item.project_item_resource import (
     labelled_resource_args,
 )
 from spine_engine.utils.helpers import (
-    resolve_python_interpreter,
+    resolve_current_python_interpreter,
     ItemExecutionFinishState,
     PartCount,
     ExecutionDirection as ED,
@@ -674,7 +674,7 @@ class Jump(ConnectionBase):
             with tempfile.TemporaryFile("w+", encoding="utf-8") as script_file:
                 script_file.write(script)
                 script_file.seek(0)
-                python = resolve_python_interpreter("")
+                python = resolve_current_python_interpreter()
                 result = subprocess.run(
                     [python, "-", *expanded_args], encoding="utf-8", stdin=script_file, capture_output=True
                 )

--- a/spine_engine/utils/helpers.py
+++ b/spine_engine/utils/helpers.py
@@ -65,8 +65,6 @@ class AppSettings:
 
     def __init__(self, settings):
         """
-        Init.
-
         Args:
             settings (dict)
         """
@@ -141,19 +139,36 @@ def resolve_current_python_interpreter():
     return EMBEDDED_PYTHON  # Use embedded <app_install_dir>/Tools/python.exe
 
 
-def resolve_julia_executable(julia_path):
-    """if given julia_path is empty, tries to find the path to Julia
-    in user's PATH env variable. If Julia is not found in PATH,
-    returns an empty string.
+def resolve_julia_executable(settings):
+    """Returns path to Julia executable from settings, and, if not set, path to default Julia executable.
+
+    Args:
+        settings (AppSettings): application settings
+
+    Returns:
+        str: path to Julia executable
+    """
+    path = settings.value("appSettings/juliaPath")
+    if path:
+        return path
+    return resolve_default_julia_executable()
+
+
+def resolve_default_julia_executable():
+    """Returns path to default Julia executable.
+
+    Tries to find the path to Julia in user's PATH env variable.
+    If Julia is not found in PATH, returns an empty string.
 
     Note: In the long run, we should decide whether this is something we want to do
     because adding julia-x.x./bin/ dir to the PATH is not recommended because this
     also exposes some .dlls to other programs on user's (windows) system. I.e. it
     may break other programs, and this is why the Julia installer does not
     add (and does not even offer the chance to add) Julia to PATH.
+
+    Returns:
+        str: path to Julia executable
     """
-    if julia_path != "":
-        return julia_path
     return resolve_executable_from_path(JULIA_EXECUTABLE)
 
 

--- a/spine_engine/utils/helpers.py
+++ b/spine_engine/utils/helpers.py
@@ -10,10 +10,7 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
 
-"""
-Helpers functions and classes.
-
-"""
+""" Helpers functions and classes. """
 import collections
 import os
 import sys
@@ -114,13 +111,27 @@ def resolve_conda_executable(conda_path):
     return conda_exe
 
 
-def resolve_python_interpreter(python_path):
-    """If given python_path is empty, returns the
-    full path to Python interpreter depending on user's
-    settings and whether the app is frozen or not.
+def resolve_python_interpreter(settings):
+    """Returns a path to Python interpreter in settings or the current executable if none is set.
+
+    Args:
+        settings (AppSettings): settings
+
+    Returns:
+        str: path to Python interpreter
     """
-    if python_path != "":
-        return python_path
+    path = settings.value("appSettings/pythonPath")
+    if path:
+        return path
+    return resolve_current_python_interpreter()
+
+
+def resolve_current_python_interpreter():
+    """Returns a path to current Python interpreter.
+
+    Returns:
+        str: path to Python interpreter
+    """
     if not getattr(sys, "frozen", False):
         return sys.executable  # Use current Python
     # We are frozen


### PR DESCRIPTION
This PR breaks `resolve_python_interpreter()` and `resolve_julia_executable()` functions into two: one returns the system's default executable (from PATH) and one that returns the executable from application settings (falling back to PATH, if not found).

This lays groundwork for further changes in Spine Toolbox and spine-items.

Re spine-tools/Spine-Toolbox#2446

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
