### PR TITLE
Fix command line arg parsing from string

### DIFF
--- a/spine_engine/utils/command_line_arguments.py
+++ b/spine_engine/utils/command_line_arguments.py
@@ -9,11 +9,7 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-
-"""
-Split command line arguments.
-
-"""
+""" Split command line arguments. """
 
 
 def split_cmdline_args(arg_string):
@@ -40,7 +36,7 @@ def split_cmdline_args(arg_string):
             quoted_context = False
         elif not character.isspace() or quoted_context:
             current_word = current_word + character
-        else:
+        elif current_word:
             tokens.append(current_word)
             current_word = ""
     if current_word:

--- a/tests/utils/test_command_line_args.py
+++ b/tests/utils/test_command_line_args.py
@@ -10,10 +10,7 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
 
-"""
-Unit tests for command line args module.
-
-"""
+""" Unit tests for command line args module. """
 
 import unittest
 from spine_engine.utils.command_line_arguments import split_cmdline_args
@@ -33,6 +30,10 @@ class TestToolSpecification(unittest.TestCase):
         self.assertEqual(splitted, ["--file=file name with spaces.dat", "-i", "3"])
         splitted = split_cmdline_args("'quotation \"within\" a quotation'")
         self.assertEqual(splitted, ['quotation "within" a quotation'])
+        splitted = split_cmdline_args("  ")
+        self.assertEqual(splitted, [])
+        splitted = split_cmdline_args("-a  -b")
+        self.assertEqual(splitted, ["-a", "-b"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
User may accidentally enter multiple spaces between the arguments which we incorrectly parsed as empty arguments. This PR fixes the issue.

No associated issue

## Checklist before merging
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
