### PR TITLE
Always store connection's filter settings

### DIFF
--- a/spine_engine/project_item/connection.py
+++ b/spine_engine/project_item/connection.py
@@ -458,11 +458,7 @@ class ResourceConvertingConnection(ConnectionBase):
         d = super().to_dict()
         if self.options:
             d["options"] = self.options.copy()
-        if (
-            self._filter_settings.has_filters()
-            or self._filter_settings.enabled_filter_types != DEFAULT_ENABLED_FILTER_TYPES
-        ):
-            d["filter_settings"] = self._filter_settings.to_dict()
+        d["filter_settings"] = self._filter_settings.to_dict()
         return d
 
     @staticmethod


### PR DESCRIPTION
We now store connection's filter settings unconditionally so they never get lost. This fixes a bug where the value of "Check new filters automatically" was lost on undo/redo or when saving the project in Toolbox.

## Checklist before merging
- [x] Code has been formatted by black
- [x] Unit tests pass
