### PR TITLE
Fix unit tests with latest jupyter_client

### DIFF
--- a/spine_engine/server/engine_server.py
+++ b/spine_engine/server/engine_server.py
@@ -83,7 +83,8 @@ class EngineServer(threading.Thread):
         """Closes the server by sending a KILL message to this thread using a PAIR socket."""
         if self.auth is not None:
             self.auth.stop()
-            time.sleep(0.2)  # wait a bit until authenticator has been closed
+            while self.auth.is_alive():
+                pass
         self.ctrl_msg_sender.send(b"KILL")
         self.join()  # Wait for the thread to finish and sockets to close
         self.ctrl_msg_sender.close()  # Close this in the same thread that it was created in

--- a/tests/project_item/test_ExecutableItem.py
+++ b/tests/project_item/test_ExecutableItem.py
@@ -10,10 +10,7 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
 
-"""
-Unit tests for ExecutableItem.
-
-"""
+""" Unit tests for ExecutableItem. """
 from tempfile import TemporaryDirectory
 import unittest
 from unittest import mock

--- a/tests/server/test_EngineServer.py
+++ b/tests/server/test_EngineServer.py
@@ -10,9 +10,7 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
 
-"""
-Unit tests for EngineServer class.
-"""
+""" Unit tests for EngineServer class. """
 
 import threading
 import unittest
@@ -175,7 +173,7 @@ class TestEngineServer(unittest.TestCase):
         self.assertTrue(server.ctrl_msg_sender.closed)  # PAIR socket should be closed
         self.assertTrue(server._context.closed)  # Context should be closed
         self.assertFalse(server.is_alive())  # server thread should not be alive
-        self.assertEqual(threading.active_count(), 1)  # Only one thread running after close
+        self.assertTrue(all(thread.name != "EngineServerThread" for thread in threading.enumerate()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`KernelExecutionManager` tests leave an extra thread running with latest `jupyter_client` package which makes `test_engineserver_close()` fail because thread count is not necessarily 1 anymore.

No associated issue.

## Checklist before merging
- [ ] Unit tests pass
