### PR TITLE
Fix resolve python interpreter when frozen

### DIFF
--- a/spine_engine/config.py
+++ b/spine_engine/config.py
@@ -10,11 +10,7 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
 
-"""
-Application constants.
-
-"""
-
+"""Spine Engine constants."""
 import os
 import sys
 

--- a/spine_engine/utils/helpers.py
+++ b/spine_engine/utils/helpers.py
@@ -130,9 +130,10 @@ def resolve_current_python_interpreter():
     """
     if not is_frozen():
         return sys.executable
-    path = resolve_executable_from_path(PYTHON_EXECUTABLE)
-    if path != "":
-        return path
+    if not sys.platform == "win32":
+        path = resolve_executable_from_path(PYTHON_EXECUTABLE)
+        if path != "":
+            return path
     return EMBEDDED_PYTHON
 
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -201,11 +201,12 @@ class TestPythonInterpreter(unittest.TestCase):
         settings = TestAppSettings("")
         p = resolve_python_interpreter(settings)
         self.assertEqual(sys.executable, p)
-        with mock.patch("spine_engine.utils.helpers.is_frozen") as mock_helpers_is_frozen:
-            mock_helpers_is_frozen.return_value = True
-            p = resolve_python_interpreter(settings)
-            self.assertIsNone(p)
-            mock_helpers_is_frozen.assert_called()
+        if sys.platform == "win32":
+            with mock.patch("spine_engine.utils.helpers.is_frozen") as mock_helpers_is_frozen:
+                mock_helpers_is_frozen.return_value = True
+                p = resolve_python_interpreter(settings)
+                self.assertIsNone(p)  # This is None only on Win. # FIXME: Find a way to mock is_frozen() in config.py
+                mock_helpers_is_frozen.assert_called()
 
 
 class TestAppSettings:


### PR DESCRIPTION
Always use embedded Python as default when frozen and on Windows. We cannot search python from the PATH because `%USERPROFILE%/AppData/Local/Microsoft/WindowsApps/` is in PATH **by default on all users** and this dir contains a python.exe that either opens the Microsoft Store or opens the Python that was downloaded from the Microsoft Store.

Fixes spine-tools/Spine-Toolbox#2823

## Checklist before merging
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
