### PR TITLE
Fix issues with jumps

### DIFF
--- a/spine_engine/project_item/connection.py
+++ b/spine_engine/project_item/connection.py
@@ -589,8 +589,10 @@ class Connection(ResourceConvertingConnection):
 class Jump(ConnectionBase):
     """Represents a conditional jump between two project items."""
 
+    _DEFAULT_CONDITION = {"type": "python-script", "script": "exit(1)", "specification": ""}
+
     def __init__(
-        self, source_name, source_position, destination_name, destination_position, condition={}, cmd_line_args=()
+        self, source_name, source_position, destination_name, destination_position, condition=None, cmd_line_args=()
     ):
         """
         Args:
@@ -598,11 +600,11 @@ class Jump(ConnectionBase):
             source_position (str): source anchor's position
             destination_name (str): destination project item's name
             destination_position (str): destination anchor's position
-            condition (dict): jump condition
+            condition (dict, optional): jump condition
+            cmd_line_args (Iterable of str): command line arguments
         """
         super().__init__(source_name, source_position, destination_name, destination_position)
-        default_condition = {"type": "python-script", "script": "exit(1)", "specification": ""}
-        self.condition = condition if condition else default_condition
+        self.condition = condition if condition is not None else self._DEFAULT_CONDITION
         self._resources_from_source = set()
         self._resources_from_destination = set()
         self.cmd_line_args = list(cmd_line_args)

--- a/spine_engine/project_item/executable_item_base.py
+++ b/spine_engine/project_item/executable_item_base.py
@@ -10,10 +10,7 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
 
-"""
-Contains ExecutableItem, a project item's counterpart in execution as well as support utilities.
-
-"""
+""" Contains ExecutableItem, a project item's counterpart in execution as well as support utilities. """
 from hashlib import sha1
 from pathlib import Path
 from ..utils.helpers import ExecutionDirection, ItemExecutionFinishState, shorten
@@ -28,6 +25,7 @@ class ExecutableItemBase:
             name (str): item's name
             project_dir (str): absolute path to project directory
             logger (LoggerInterface): a logger
+            group_id (str, optional): execution group identifier
         """
         self._name = name
         self._project_dir = project_dir

--- a/spine_engine/spine_engine.py
+++ b/spine_engine/spine_engine.py
@@ -275,10 +275,11 @@ class SpineEngine:
         self._thread.start()
         while True:
             msg = self._queue.get()
-            yield msg
             if msg[0] == "dag_exec_finished":
                 break
+            yield msg
         self._thread.join()
+        yield msg
 
     def answer_prompt(self, prompter_id, answer):
         """Answers the prompt for the specified prompter id."""

--- a/spine_engine/utils/helpers.py
+++ b/spine_engine/utils/helpers.py
@@ -405,7 +405,7 @@ def make_connections(connections, permitted_items):
         list of Connection: List of permitted Connections or an empty list if the DAG contains no connections
     """
     if not connections:
-        return list()
+        return []
     connections = connections_to_selected_items(connections, permitted_items)
     return connections
 
@@ -433,10 +433,10 @@ def dag_edges(connections):
     Returns:
         dict: DAG edges. Mapping of source item (node) to a list of destination items (nodes)
     """
-    edges = dict()
+    edges = {}
     for connection in connections:
         source, destination = connection.source, connection.destination
-        edges.setdefault(source, list()).append(destination)
+        edges.setdefault(source, []).append(destination)
     return edges
 
 


### PR DESCRIPTION
This PR fixes two separate issues with jumps:

- The execution manager would execute forever if the engine was stopped by user.
- Jump and all its items would be executed even when only the source item was selected. We should execute jumps only if all its items are selected for execution.

Fixes spine-tools/Spine-Toolbox#2925

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
