### PR TITLE
Fix race condition when acquiring an idle persistent manager

### DIFF
--- a/spine_engine/utils/execution_resources.py
+++ b/spine_engine/utils/execution_resources.py
@@ -10,10 +10,7 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
 
-"""
-Utilities for managing execution resources such as processes.
-
-"""
+""" Utilities for managing execution resources such as processes. """
 import threading
 
 


### PR DESCRIPTION
This may fix a Traceback that sometimes occurs during execution.

```
Exception in thread Thread-279 (_execute_item_filtered):
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
Exception in thread Thread-278 (_execute_item_filtered):
Traceback (most recent call last):
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self._target(*self._args, **self._kwargs)
  File "/home/prokjt/python-envs/spi/lib/python3.10/site-packages/spine_engine/spine_engine.py", line 528, in _execute_item_filtered
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    item_finish_state = item.execute(filtered_forward_resources, filtered_backward_resources, item_lock)
  File "/home/prokjt/python-envs/spi/lib/python3.10/site-packages/spine_items/tool/executable_item.py", line 525, in execute
    self._target(*self._args, **self._kwargs)
  File "/home/prokjt/python-envs/spi/lib/python3.10/site-packages/spine_engine/spine_engine.py", line 528, in _execute_item_filtered
    item_finish_state = item.execute(filtered_forward_resources, filtered_backward_resources, item_lock)
  File "/home/prokjt/python-envs/spi/lib/python3.10/site-packages/spine_items/tool/executable_item.py", line 525, in execute
    self._tool_instance.prepare(expanded_args)
    self._tool_instance.prepare(expanded_args)
  File "/home/prokjt/python-envs/spi/lib/python3.10/site-packages/spine_items/tool/tool_instance.py", line 320, in prepare
  File "/home/prokjt/python-envs/spi/lib/python3.10/site-packages/spine_items/tool/tool_instance.py", line 320, in prepare
    self.exec_mngr = PythonPersistentExecutionManager(
    self.exec_mngr = PythonPersistentExecutionManager(
  File "/home/prokjt/python-envs/spi/lib/python3.10/site-packages/spine_engine/execution_managers/persistent_execution_manager.py", line 802, in __init__
  File "/home/prokjt/python-envs/spi/lib/python3.10/site-packages/spine_engine/execution_managers/persistent_execution_manager.py", line 802, in __init__
    self._persistent_manager = _persistent_manager_factory.new_persistent_manager(
  File "/home/prokjt/python-envs/spi/lib/python3.10/site-packages/spine_engine/execution_managers/persistent_execution_manager.py", line 593, in new_persistent_manager
    del self.persistent_managers[key]
KeyError: '66a7cdc2861347fbb9e7bbb8e779d384'
    self._persistent_manager = _persistent_manager_factory.new_persistent_manager(
  File "/home/prokjt/python-envs/spi/lib/python3.10/site-packages/spine_engine/execution_managers/persistent_execution_manager.py", line 593, in new_persistent_manager
    del self.persistent_managers[key]
KeyError: '66a7cdc2861347fbb9e7bbb8e779d384'
```

No associated issue.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
