### PR TITLE
Fix datapackages in Data connection's data files

### DIFF
--- a/spine_engine/project_item/connection.py
+++ b/spine_engine/project_item/connection.py
@@ -418,9 +418,12 @@ class ResourceConvertingConnection(ConnectionBase):
         final_resources = []
         csv_filepaths = []
         for r in resources:
-            if r.hasfilepath and os.path.splitext(r.path)[1].lower() == ".csv":
-                csv_filepaths.append(r.path)
-                continue
+            if r.hasfilepath:
+                if os.path.splitext(r.path)[1].lower() == ".csv":
+                    csv_filepaths.append(r.path)
+                    continue
+                if os.path.basename(r.path) == "datapackage.json":
+                    continue
             final_resources.append(r)
         if not csv_filepaths:
             return final_resources


### PR DESCRIPTION
This PR fixes a bug where the `datapackage.json` resource would show up twice in predecessor items if  Data connection's data files were packaged into a datapackage.

No associated issue.

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [ ] Unit tests pass
