### PR TITLE
Do not put engine state in exec_finished event

### DIFF
--- a/spine_engine/execution_managers/process_execution_manager.py
+++ b/spine_engine/execution_managers/process_execution_manager.py
@@ -10,10 +10,7 @@
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
 
-"""
-Contains the ProcessExecutionManager class.
-
-"""
+""" Contains the ProcessExecutionManager class. """
 
 import subprocess
 import sys

--- a/spine_engine/spine_engine.py
+++ b/spine_engine/spine_engine.py
@@ -322,7 +322,6 @@ class SpineEngine:
                     {
                         "item_name": event.item_name,
                         "direction": event.direction,
-                        "state": str(self._state),
                         "item_state": ItemExecutionFinishState.FAILURE,
                     },
                 )
@@ -339,7 +338,6 @@ class SpineEngine:
                     {
                         "item_name": event.item_name,
                         "direction": event.direction,
-                        "state": str(self._state),
                         "item_state": event.item_finish_state,
                     },
                 )
@@ -362,7 +360,6 @@ class SpineEngine:
                 {
                     "item_name": item.name,
                     "direction": ED.FORWARD,
-                    "state": str(self._state),
                     "item_state": ItemExecutionFinishState.STOPPED,
                 },
             )

--- a/tests/server/util/test_EventDataConverter.py
+++ b/tests/server/util/test_EventDataConverter.py
@@ -28,7 +28,6 @@ class TestEventDataConverter(unittest.TestCase):
                 {
                     "item_name": "helloworld",
                     "direction": ExecutionDirection.BACKWARD,
-                    "state": "RUNNING",
                     "item_state": ItemExecutionFinishState.SUCCESS,
                 },
             ),
@@ -37,7 +36,6 @@ class TestEventDataConverter(unittest.TestCase):
                 {
                     "item_name": "Data Connection 1",
                     "direction": ExecutionDirection.BACKWARD,
-                    "state": "RUNNING",
                     "item_state": ItemExecutionFinishState.SUCCESS,
                 },
             ),
@@ -56,7 +54,6 @@ class TestEventDataConverter(unittest.TestCase):
                 {
                     "item_name": "Data Connection 1",
                     "direction": ExecutionDirection.FORWARD,
-                    "state": "RUNNING",
                     "item_state": ItemExecutionFinishState.SUCCESS,
                 },
             ),
@@ -103,7 +100,6 @@ class TestEventDataConverter(unittest.TestCase):
                 {
                     "item_name": "helloworld",
                     "direction": ExecutionDirection.FORWARD,
-                    "state": "RUNNING",
                     "item_state": ItemExecutionFinishState.SUCCESS,
                 },
             ),


### PR DESCRIPTION
Engine state is not used in the exec_finished event.

No associated issue

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
