### PR TITLE
Yield msg first, then close thread

### DIFF
--- a/spine_engine/spine_engine.py
+++ b/spine_engine/spine_engine.py
@@ -280,8 +280,8 @@ class SpineEngine:
             if msg[0] == "dag_exec_finished":
                 break
             yield msg
-        self._thread.join()
         yield msg
+        self._thread.join()
 
     def answer_prompt(self, prompter_id, answer):
         """Answers the prompt for the specified prompter id."""


### PR DESCRIPTION
Fixes a hangup when running remote executions repeatedly.

No associated issue.

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted by black & isort
- [x] Unit tests pass
