### PR TITLE
Fix empty file packs in command line arguments

### DIFF
--- a/spine_engine/logger_interface.py
+++ b/spine_engine/logger_interface.py
@@ -11,7 +11,6 @@
 ######################################################################################################################
 """A logger interface for static type checking."""
 from typing import Protocol
-from PySide6.QtCore import Signal
 
 
 class MessageSignal(Protocol):
@@ -27,21 +26,21 @@ class MessageBoxSignal(Protocol):
 class LoggerInterface(Protocol):
     """Protocol for logger that uses signals that can be emitted to send messages to an output device."""
 
-    msg: MessageSignal | Signal
+    msg: MessageSignal
     """Emits a notification message."""
-    msg_success: MessageSignal | Signal
+    msg_success: MessageSignal
     """Emits a message on success"""
-    msg_warning: MessageSignal | Signal
+    msg_warning: MessageSignal
     """Emits a warning message."""
-    msg_error: MessageSignal | Signal
+    msg_error: MessageSignal
     """Emits an error message."""
-    msg_proc: MessageSignal | Signal
+    msg_proc: MessageSignal
     """Emits a message originating from a subprocess (usually something printed to stdout)."""
-    msg_proc_error: MessageSignal | Signal
+    msg_proc_error: MessageSignal
     """Emits an error message originating from a subprocess (usually something printed to stderr)."""
-    information_box: MessageBoxSignal | Signal
+    information_box: MessageBoxSignal
     """Requests an 'information message box' (e.g. a message window) to be opened with a given title and message."""
-    error_box: MessageBoxSignal | Signal
+    error_box: MessageBoxSignal
     """Requests an 'error message box' to be opened with a given title and message."""
 
 

--- a/spine_engine/project_item/project_item_resource.py
+++ b/spine_engine/project_item/project_item_resource.py
@@ -446,7 +446,7 @@ def make_cmd_line_arg(arg_spec: dict | str) -> CmdLineArg:
 
 def labelled_resource_args(
     resources: Iterable[ProjectItemResource], stack: ExitStack, db_checkin: bool = False, db_checkout: bool = False
-) -> dict[str, list]:
+) -> dict[str, list[str]]:
     """Generates command line arguments for each resource.
 
     Args:
@@ -470,7 +470,7 @@ def labelled_resource_args(
 
 
 def expand_cmd_line_args(
-    args: list[CmdLineArg], label_to_arg: dict[str, list[CmdLineArg]], logger: LoggerInterface
+    args: list[CmdLineArg], label_to_arg: dict[str, list[str]], logger: LoggerInterface
 ) -> list[str]:
     """Expands command line arguments by replacing resource labels by URLs/paths.
 
@@ -480,7 +480,7 @@ def expand_cmd_line_args(
         logger: a logger
 
     Returns:
-        list of str: command line arguments as strings
+        command line arguments as strings
     """
     expanded_args = list()
     for arg in args:
@@ -488,9 +488,8 @@ def expand_cmd_line_args(
             expanded_args.append(str(arg))
             continue
         expanded = label_to_arg.get(str(arg))
-        if expanded is None:
+        if expanded is None or any(not arg for arg in expanded):
             logger.msg_warning.emit(f"No resources matching argument '{arg}'.")
             continue
-        if expanded:
-            expanded_args.extend(expanded)
+        expanded_args.extend(expanded)
     return expanded_args

--- a/tests/project_item/test_project_item_resource.py
+++ b/tests/project_item/test_project_item_resource.py
@@ -144,6 +144,13 @@ class TestExpandCmdLineArgs(unittest.TestCase):
         expanded_args = expand_cmd_line_args(args, label_to_arg, self._logger)
         self.assertEqual(expanded_args, ["--no-worries"])
 
+    def test_empty_file_pack(self):
+        args = [LabelArg("file label")]
+        label_to_arg = {"file label": [""]}
+        expanded_args = expand_cmd_line_args(args, label_to_arg, self._logger)
+        self.assertEqual(expanded_args, [])
+        self._logger.msg_warning.emit.assert_called_once_with("No resources matching argument 'file label'.")
+
 
 class TestDatabaseResource(unittest.TestCase):
     def test_schema_is_stored_in_metadata(self):


### PR DESCRIPTION
Empty file pack resources expanded to an empty command line argument. We now drop such empty arguments and issue a warning instead.

No associated issue

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black & isort
- [ ] Unit tests pass
